### PR TITLE
fix: break the loop if header is application/octet-stream

### DIFF
--- a/transifex.py
+++ b/transifex.py
@@ -68,10 +68,7 @@ def check_for_task_id(url):
             url=url,
             headers=HEADERS,
         )
-        try:
-            if response.json()["data"]["attribute"]["status"] in STATUS:
-                pass
-        except:
+        if response.headers["Content-Type"] != "application/octet-stream":
             flag = False
     return response.content
 


### PR DESCRIPTION
since using JSON fields might create some issues on different scenarios, we'll check if the header type is application/octet-stream, then we'll break the loop and save the data.